### PR TITLE
Fallback to ratpack execution to get current spans

### DIFF
--- a/src/main/java/ratpack/zipkin/internal/RatpackServerClientLocalSpanState.java
+++ b/src/main/java/ratpack/zipkin/internal/RatpackServerClientLocalSpanState.java
@@ -62,10 +62,20 @@ public class RatpackServerClientLocalSpanState implements ServerClientAndLocalSp
 
   @Override
   public Span getCurrentClientSpan() {
+
     return registry.get()
         .maybeGet(CurrentClientSpanValue.class)
         .map(TypedValue::get)
-        .orElse(null);
+        .orElseGet(() -> {
+          if (Execution.isManagedThread()) {
+            return Execution.current()
+                    .maybeGet(CurrentClientSpanValue.class)
+                    .map(TypedValue::get)
+                    .orElse(null);
+          } else {
+            return null;
+          }
+        });
   }
 
   @Override
@@ -73,7 +83,16 @@ public class RatpackServerClientLocalSpanState implements ServerClientAndLocalSp
     return registry.get()
         .maybeGet(CurrentLocalSpanValue.class)
         .map(TypedValue::get)
-        .orElse(null);
+        .orElseGet(() -> {
+          if (Execution.isManagedThread()) {
+            return Execution.current()
+                    .maybeGet(CurrentLocalSpanValue.class)
+                    .map(TypedValue::get)
+                    .orElse(null);
+          } else {
+            return null;
+          }
+        });
   }
 
   @Override
@@ -86,7 +105,16 @@ public class RatpackServerClientLocalSpanState implements ServerClientAndLocalSp
     return registry.get()
         .maybeGet(CurrentServerSpanValue.class)
         .map(TypedValue::get)
-        .orElse(ServerSpan.EMPTY);
+        .orElseGet(() -> {
+          if (Execution.isManagedThread()) {
+            return Execution.current()
+                    .maybeGet(CurrentServerSpanValue.class)
+                    .map(TypedValue::get)
+                    .orElse(ServerSpan.EMPTY);
+          } else {
+            return ServerSpan.EMPTY;
+          }
+        });
   }
 
   @Override
@@ -114,7 +142,7 @@ public class RatpackServerClientLocalSpanState implements ServerClientAndLocalSp
     return endpoint;
   }
 
-  private abstract class TypedValue<T> {
+  private abstract static class TypedValue<T> {
     private T value;
 
     TypedValue(final T value) {
@@ -126,20 +154,20 @@ public class RatpackServerClientLocalSpanState implements ServerClientAndLocalSp
     }
   }
 
-  private class CurrentLocalSpanValue extends TypedValue<Span> {
-    CurrentLocalSpanValue(final Span value) {
+  public static class CurrentLocalSpanValue extends TypedValue<Span> {
+    public CurrentLocalSpanValue(final Span value) {
       super(value);
     }
   }
 
-  private class CurrentClientSpanValue extends TypedValue<Span> {
-    CurrentClientSpanValue(final Span value) {
+  public static class CurrentClientSpanValue extends TypedValue<Span> {
+    public CurrentClientSpanValue(final Span value) {
       super(value);
     }
   }
 
-  private class CurrentServerSpanValue extends TypedValue<ServerSpan> {
-    CurrentServerSpanValue(final ServerSpan value) {
+  public static class CurrentServerSpanValue extends TypedValue<ServerSpan> {
+    public CurrentServerSpanValue(final ServerSpan value) {
       super(value);
     }
   }


### PR DESCRIPTION
this will allow propagating current spans to execution of ratpack's parallel batch

usage:

```java
List<Promise> promises = ...;
Span maybeLocalSpan = ...;
ServerSpan maybeServerSpan = ...;
return ParallelBatch.of(promises)
	.execInit(e -> {
		if (maybeLocalSpan != null) {
			e.add(new RatpackServerClientLocalSpanState.CurrentLocalSpanValue(maybeLocalSpan));
		}
		if (maybeServerSpan != null) {
			e.add(new RatpackServerClientLocalSpanState.CurrentServerSpanValue(maybeServerSpan));
		}
	})
	.yield();
```

@llinder @Bijnagte @jeff-blaisdell 